### PR TITLE
dont fetch databases starting with underscore

### DIFF
--- a/_attachments/inception/couchdata.js
+++ b/_attachments/inception/couchdata.js
@@ -74,12 +74,12 @@ define(function(require, exports, module) {
       return $.Deferred(function (deferred) {
 
         couch.get("/_all_dbs").then(function (dbs) {
-
+          
+          dbs = _.reject(dbs, function(db) { return db.charAt(0) === "_" });
+          
           $.when.apply(this, _.map(dbs, designDocs)).then(function () {
             _.each(arguments, function(ddoc, i) {
-              if (dbs[i].charAt(0) !== "_") {
-                databases[dbs[i]] = ddoc[0].rows;
-              }
+              databases[dbs[i]] = ddoc.rows;
             });
             deferred.resolve(databases);
           });


### PR DESCRIPTION
I was getting weird errors from google chrome's xhr thingy when I tried to fetch databases that started with underscores. removing them from the list before fetching them fixed the problem and is also slightly more performant

p.s. if all these small pull requests are annoying let me know :D
