### PR TITLE
javascript highlight

### DIFF
--- a/_attachments/inception/buffers.js
+++ b/_attachments/inception/buffers.js
@@ -58,6 +58,7 @@ define(function(require, exports, module) {
       contentType = contentType.split(";")[0];
       var tmp = {
           "application/x-javascript":"javascript",
+          "application/javascript":"javascript",
           "text/css":"css",
           "text/html":"html"
       };


### PR DESCRIPTION
Hi dale, did an hyper simple change to let the documents served as 'application/javascript' to be highlighted as javascript.

bye

Fabio Montagna
